### PR TITLE
SQLCipher 4.0.1 / SQLite 3.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ db.close();
 
 # SQLCipher
 
-A copy of the source for SQLCipher 3.4.1 is bundled, which is based on SQLite 3.15.2.
+A copy of the source for SQLCipher 4.0.1 is bundled, which is based on SQLite 3.26.0.
 
 ## OpenSSL
 

--- a/deps/common-sqlite.gypi
+++ b/deps/common-sqlite.gypi
@@ -1,6 +1,6 @@
 {
   'variables': {
-      'sqlite_version%':'3020001',
+      'sqlite_version%':'3026000',
       "toolset%":''
   },
   'target_defaults': {

--- a/deps/sqlcipher-amalgamation-3020001.tar.gz
+++ b/deps/sqlcipher-amalgamation-3020001.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e56b16ea6525c1724c37b9a082cc3290c34a1eb08aaddde5cf91fce43689eb9b
-size 5220800

--- a/deps/sqlcipher-amalgamation-3026000.tar.gz
+++ b/deps/sqlcipher-amalgamation-3026000.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a61b64848b5825a3ce45d26e3842a2ed8dc140f55395a47a98bfbc1e02f8e366
+size 5430504


### PR DESCRIPTION
Updates SQLCipher to [4.0.1](https://www.zetetic.net/blog/2018/12/18/sqlcipher-401-release/) which is based on SQLite 3.26.0.

TODO:

- [ ] Version bump
- [ ] Update `CHANGELOG.md`
