### PR TITLE
SQLCipher 4.4.0 / SQLite 3.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.1.0
+
+- Update to SQLCipher 4.3.0 / SQLite 3.30.1.
 ## 4.0.0
 
  - Update to SQLCipher 4.2.0 / SQLite 3.28.0.

--- a/README.md
+++ b/README.md
@@ -4,26 +4,16 @@ While the `node-sqlite3` project does include support for compiling against sqlc
 
 ## Supported platforms
 
-Tests are run and pre-built binaries are made available for the following platforms:
-* Node 8, 10 and 12.
-* Electron 3, 4 and 5.
-* Windows, Mac and Linux.
+Binaries are built against N-API 3 and 6, on MacOS, Windows (ia32 and x64) and Linux (x64).
 
-# Requirements
+Node 10+ and Electron 6+ is supported.
 
-### Windows
-
- * Visual Studio 2015
- * Python 2.7
-
-### Mac
-
- * `brew install openssl@1.1`
+Other platforms/architectures may work by building from source - see the section below.
 
 # Installation
 
 ```sh
-yarn install "@journeyapps/sqlcipher"
+yarn add "@journeyapps/sqlcipher"
 # Or: npm install --save "@journeyapps/sqlcipher"
 ```
 
@@ -36,8 +26,11 @@ var sqlite3 = require('@journeyapps/sqlcipher').verbose();
 var db = new sqlite3.Database('test.db');
 
 db.serialize(function() {
-  // Required to open a database created with SQLCipher 3.x
-  db.run("PRAGMA cipher_compatibility = 3");
+  // This is the default, but it is good to specify explicitly:
+  db.run("PRAGMA cipher_compatibility = 4");
+
+  // To open a database created with SQLCipher 3.x, use this:
+  // db.run("PRAGMA cipher_compatibility = 3");
 
   db.run("PRAGMA key = 'mysecret'");
   db.run("CREATE TABLE lorem (info TEXT)");
@@ -58,13 +51,29 @@ db.close();
 
 # SQLCipher
 
-A copy of the source for SQLCipher 4.3.0 is bundled, which is based on SQLite 3.31.0.
+A copy of the source for SQLCipher 4.4.0 is bundled, which is based on SQLite 3.31.0.
+
+## Building from source.
+
+This is done automatically by node-pre-gyp when installing on a platform without pre-built binaries.
+However, this does require some additional setup, and is likely to run against obscure errors when installing.
+
+Requirements:
+
+### Mac
+
+ * `brew install openssl@1.1`
+
+### Windows
+
+ * Visual Studio 2015
+ * Python 2.7
 
 ## OpenSSL
 
 SQLCipher depends on OpenSSL. When using NodeJS, OpenSSL is provided by NodeJS itself. For Electron, we need to use our own copy.
 
-For Windows we bundle OpenSSL 1.0.2n. Pre-built libraries are used from https://slproweb.com/products/Win32OpenSSL.html.
+For Windows, we bundle OpenSSL 1.0.2n. Pre-built libraries are used from https://slproweb.com/products/Win32OpenSSL.html.
 
 On Mac we build against OpenSSL installed via brew, but statically link it so that end-users do not need to install it.
 
@@ -80,7 +89,7 @@ Documentation for the SQLCipher extension is available [here](https://www.zeteti
 
 [mocha](https://github.com/visionmedia/mocha) is required to run unit tests.
 
-In sqlite3's directory (where its `package.json` resides) run the following:
+In sqlite3's directory (where its `package.json` resides) run the following:
 
     npm install --build-from-source
     npm test
@@ -92,7 +101,7 @@ To publish a new version, run:
     npm version minor -m "%s [publish binary]"
     npm publish
 
-Publishing of the prebuilt binaries is performed on CircleCI and AppVeyor.
+Publishing of the prebuilt binaries is performed on CircleCI.
 
 # Acknowledgments
 

--- a/SQLCipher.md
+++ b/SQLCipher.md
@@ -11,6 +11,10 @@ git clone git@github.com:sqlcipher/sqlcipher.git
 cd sqlcipher
 ./configure
 make sqlite3.c
+
+VERSION=3031000
+mkdir sqlcipher-amalgamation-$VERSION
+cp sqlite3.c sqlite3.h shell.c sqlite3ext.h VERSION sqlcipher-amalgamation-$VERSION/
 ```
 
 The above produces 4 files of interest:
@@ -23,7 +27,7 @@ sqlite3ext.h # optional
 VERSION # optional
 ```
 
-Copy these files to a new folder, `sqlcipher-amalgamation-<version>`.
+The files are copied to: `sqlcipher-amalgamation-<version>`.
 
 ## Step 2: Get OpenSSL libraries
 
@@ -45,6 +49,10 @@ Copy the header files (include folder) to `sqlcipher-amalgamation-<version>/open
 ## Step 3: Build the archive
 
 Archive the folder as `deps/sqlcipher-amalgamation-<version>.tar.gz`, and update the version number in `common-sqlite.gypi` (must be the same).
+
+```
+tar czf sqlcipher-amalgamation-$VERSION.tar.gz sqlcipher-amalgamation-$VERSION
+```
 
 ## Step 4: Test the build
 

--- a/deps/sqlcipher-amalgamation-3031000.tar.gz
+++ b/deps/sqlcipher-amalgamation-3031000.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef782f7fd27484b9c2c7c043f162e5294ec06e23ef9df60d9c5cffb5dc343163
-size 5507468
+oid sha256:afabc65e0907afef636de3940b1e08967600f0290cb30b8c2269dbd18f22f8a6
+size 5545265


### PR DESCRIPTION
Previous version was SQLCipher 4.3.0 / SQLite 3.30.1 (incorrectly listed as 3.31.0).