### PR TITLE
Add notes on electron-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ A copy of the source for SQLCipher 4.4.0 is bundled, which is based on SQLite 3.
 
 ## Building from source.
 
-This is done automatically by node-pre-gyp when installing on a platform without pre-built binaries.
+This is done automatically by node-pre-gyp when installing on a platform without pre-built binaries. This should generally
+not be required with later versions, since two pre-built versions (N-API 3 and N-API 6) cover all electron and node versions.
+
 However, this does require some additional setup, and is likely to run against obscure errors when installing.
 
 Requirements:
@@ -68,6 +70,28 @@ Requirements:
 
  * Visual Studio 2015
  * Python 2.7
+
+## Usage with electron-forge / electron-rebuild
+
+[electron-forge](https://www.electronforge.io/) uses [electron-rebuild](https://github.com/electron/electron-rebuild) and attempts to rebuild this library from source by default, in a way
+that is _not_ compatible with the way `node-pre-gyp` is used here.
+
+The workaround is to disable the rebuilding:
+1. If using Electron 11+, use a node version that supports N-API 6+ (v10.20.0+ / v12.17.0+ / v14.0.0).
+2. After `npm install` / `yarn install`, make sure that the folder `node_modules/@journeyapps/sqlcipher/lib/binding/napi-v6-linux-x64` exists.
+   If not, check the previous step again, remove the `node_modules` folder, and try again.
+3. Disable rebuilding of this library using the `onlyModules` option of `electron-rebuild` in your `package.json`:
+
+        "config": {
+            "forge": {
+                "electronRebuildConfig": {
+                    "onlyModules": []  // Specify other native modules here if required
+                }
+            }
+        }
+
+Note: [electron-builder](https://www.electron.build/) does not appear to have this issue, and should work directly.
+Similarly, using electron directly should just work, but do check that a compatible node version is used (see above). 
 
 ## OpenSSL
 


### PR DESCRIPTION
There are multiple issues with electron-forge / electron-builder attempting to rebuild this module.
 1. It does not support `{napi_build_version}` in the `module_path`. See https://github.com/electron/electron-rebuild/issues/554 / https://github.com/electron/electron-rebuild/issues/546.
 2. It does not use the pre-built modules. See https://github.com/electron/electron-rebuild/issues/367.
 3. When building from source, there is something wrong in the build environment causing a compile error (#63).

The workaround is to not attempt to rebuild the this module, since it's not required.

Fixes #53 #54 #56 #61 #63.

Supersedes #60.