### PR TITLE
v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.3.0
+
+- Pre-built binaries for macos/darwin arm64.
+- Add typescript types.
+- Don't fallback to building from source.
+- Smaller NPM package (build dependencies not included anymore).
+
 ## 5.2.0
 
 - Statically link OpenSSL on Linux and Windows, in addition to MacOS. No more DLLs distributed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To release a new version:
 
 **1)** Ensure tests are passing
 
-Before considering a release all the tests need to be passing on appveyor and travis.
+Before considering a release all the tests need to be passing on CircleCI.
 
 **2)** Bump commit
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@journeyapps/sqlcipher",
   "description": "Asynchronous, non-blocking SQLCipher bindings",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "homepage": "http://github.com/journeyapps/node-sqlcipher",
   "author": {
     "name": "JourneyApps",


### PR DESCRIPTION

- Pre-built binaries for macos/darwin arm64.
- Add typescript types.
- Don't fallback to building from source.
- Smaller NPM package (build dependencies not included anymore).