### PR TITLE
v5.3.1 / Downgrade glibc requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ aliases:
   - &common-electron-linux
     resource_class: large
     docker:
-      - image: circleci/node:12.18.4
+      - image: circleci/node:12.18.4-stretch
 
     working_directory: ~/repo
 
@@ -231,71 +231,71 @@ jobs:
       PUBLISH: true
       ELECTRON_VERSION: "16.0.2"
     docker:
-      - image: circleci/node:16.9.1
+      - image: circleci/node:16.9.1-stretch
 
   build-14:
     <<: *common-build
     docker:
-      - image: circleci/node:14.11.0
+      - image: circleci/node:14.11.0-stretch
 
   build-12:
     <<: *common-build
     docker:
-      - image: circleci/node:12.6.0
+      - image: circleci/node:12.6.0-stretch
 
   build-10:
     <<: *common-build
     docker:
-      - image: circleci/node:10.16.0
+      - image: circleci/node:10.16.0-stretch
 
   # Node version should match electron's node version.
   # See https://github.com/mapbox/node-sqlite3/pull/1367
   build-electron-16:
     <<: *common-electron-linux
     docker:
-      - image: circleci/node:16.9.1
+      - image: circleci/node:16.9.1-stretch
     environment:
       ELECTRON_VERSION: "16.0.2"
 
   build-electron-11:
     <<: *common-electron-linux
     docker:
-      - image: circleci/node:12.18.3
+      - image: circleci/node:12.18.3-stretch
     environment:
       ELECTRON_VERSION: "11.2.3"
 
   build-electron-10:
     <<: *common-electron-linux
     docker:
-      - image: circleci/node:12.16.3
+      - image: circleci/node:12.16.3-stretch
     environment:
       ELECTRON_VERSION: "10.3.2"
 
   build-electron-9:
     <<: *common-electron-linux
     docker:
-      - image: circleci/node:12.14.1
+      - image: circleci/node:12.14.1-stretch
     environment:
       ELECTRON_VERSION: "9.3.1"
 
   build-electron-8:
     <<: *common-electron-linux
     docker:
-      - image: circleci/node:12.13.0
+      - image: circleci/node:12.13.0-stretch
     environment:
       ELECTRON_VERSION: "8.5.2"
 
   build-electron-7:
     <<: *common-electron-linux
     docker:
-      - image: circleci/node:12.8.1
+      - image: circleci/node:12.8.1-stretch
     environment:
       ELECTRON_VERSION: "7.1.14"
 
   build-electron-6:
     <<: *common-electron-linux
     docker:
-      - image: circleci/node:12.6.0 # Issues with 12.4.0
+      - image: circleci/node:12.6.0-stretch # Issues with 12.4.0
     environment:
       ELECTRON_VERSION: "6.1.9"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## 5.3.1
+
+- Linux: Downgrade glibc requirement to 2.24, supporting Ubuntu 16.10+ and Debian 9 (Stretch)+ again.
+
 ## 5.3.0
 
 - Pre-built binaries for macos/darwin arm64.
 - Add typescript types.
 - Don't fallback to building from source.
 - Smaller NPM package (build dependencies not included anymore).
+- Linux: Requires glibc 2.28+ (Ubuntu 18.10+).
 
 ## 5.2.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@journeyapps/sqlcipher",
-  "version": "5.2.0",
+  "version": "5.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@journeyapps/sqlcipher",
   "description": "Asynchronous, non-blocking SQLCipher bindings",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "homepage": "http://github.com/journeyapps/node-sqlcipher",
   "author": {
     "name": "JourneyApps",


### PR DESCRIPTION
Build linux bindings on Debian stretch with glibc 2.24, instead of 2.28. This allows using the module on older Ubuntu and Debian versions.

Symptoms on v5.3.0, Debian stretch:

```
Error: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by .../@journeyapps/sqlcipher/lib/binding/napi-v3-x64/node_sqlite3.node).
```
